### PR TITLE
fix: renovate warning for extra indentation

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -30,19 +30,19 @@ components:
     only:
       flavor: registry1
     charts:
-      - name: uds-gitlab-runner-config
-        namespace: gitlab-runner
-        version: 0.1.0
-        localPath: chart
-        valuesFiles:
-          - values/config-values.yaml
-      - name: gitlab-runner
-        namespace: gitlab-runner
-        url: https://charts.gitlab.io
-        gitPath: chart
-        version: "0.61.0"
-        valuesFiles:
-          - values/registry1-values.yaml
+    - name: uds-gitlab-runner-config
+      namespace: gitlab-runner
+      version: 0.1.0
+      localPath: chart
+      valuesFiles:
+        - values/config-values.yaml
+    - name: gitlab-runner
+      namespace: gitlab-runner
+      url: https://charts.gitlab.io
+      gitPath: chart
+      version: "0.61.0"
+      valuesFiles:
+        - values/registry1-values.yaml
     images:
       - "registry1.dso.mil/ironbank/gitlab/gitlab-runner/gitlab-runner:v16.8.0"
       - "registry1.dso.mil/ironbank/gitlab/gitlab-runner/gitlab-runner-helper:v16.8.0"
@@ -54,19 +54,19 @@ components:
     only:
       flavor: upstream
     charts:
-      - name: uds-gitlab-runner-config
-        namespace: gitlab-runner
-        version: 0.1.0
-        localPath: chart
-        valuesFiles:
-          - values/config-values.yaml
-      - name: gitlab-runner
-        namespace: gitlab-runner
-        url: https://charts.gitlab.io
-        gitPath: chart
-        version: "0.61.0"
-        valuesFiles:
-          - values/upstream-values.yaml
+    - name: uds-gitlab-runner-config
+      namespace: gitlab-runner
+      version: 0.1.0
+      localPath: chart
+      valuesFiles:
+        - values/config-values.yaml
+    - name: gitlab-runner
+      namespace: gitlab-runner
+      url: https://charts.gitlab.io
+      gitPath: chart
+      version: "0.61.0"
+      valuesFiles:
+        - values/upstream-values.yaml
     images:
       - "registry.gitlab.com/gitlab-org/gitlab-runner:alpine-v16.8.0"
       - "library/alpine:latest"


### PR DESCRIPTION
## Description
Renovate is attempting to update the local config version of our[ zarf yaml](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/zarf.yaml#L33C1-L38C38) because of the spacing of the `charts` block. 
...

Fixes #
Fix indentation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
