### PR TITLE
fix: build container security context

### DIFF
--- a/values/registry1-values.yaml
+++ b/values/registry1-values.yaml
@@ -66,10 +66,9 @@ runners:
         "job_id" = "${CI_JOB_ID}"
         "job_name" = "${CI_JOB_NAME}"
         "pipeline_id" = "${CI_PIPELINE_ID}"
+        "uds/user" = "${UDS_RUN_AS_USER}"
+        "uds/group" = "${UDS_RUN_AS_GROUP}"
       [runners.kubernetes.helper_container_security_context]
         run_as_non_root = true
         run_as_user = 1001
         run_as_group = 0
-      [runners.kubernetes.build_container_security_context]
-        run_as_user = 65534
-        run_as_group = 65534

--- a/values/registry1-values.yaml
+++ b/values/registry1-values.yaml
@@ -70,3 +70,6 @@ runners:
         run_as_non_root = true
         run_as_user = 1001
         run_as_group = 0
+      [runners.kubernetes.build_container_security_context]
+        run_as_user = 65534
+        run_as_group = 65534

--- a/values/upstream-values.yaml
+++ b/values/upstream-values.yaml
@@ -33,9 +33,8 @@ runners:
         "job_id" = "${CI_JOB_ID}"
         "job_name" = "${CI_JOB_NAME}"
         "pipeline_id" = "${CI_PIPELINE_ID}"
+        "uds/user" = "${UDS_RUN_AS_USER}"
+        "uds/group" = "${UDS_RUN_AS_GROUP}"
       [runners.kubernetes.helper_container_security_context]
         run_as_user = 1001
-        run_as_group = 0
-      [runners.kubernetes.build_container_security_context]
-        run_as_user = 65534
-        run_as_group = 65534      
+        run_as_group = 0   

--- a/values/upstream-values.yaml
+++ b/values/upstream-values.yaml
@@ -36,4 +36,6 @@ runners:
       [runners.kubernetes.helper_container_security_context]
         run_as_user = 1001
         run_as_group = 0
-      
+      [runners.kubernetes.build_container_security_context]
+        run_as_user = 65534
+        run_as_group = 65534      


### PR DESCRIPTION
## Description
Because Pepr mutates container security contexts if the user / group is not set, is set to 0, or is set to user name not uid, some pipeline jobs fail.

For example, the cosign component uses the chainguard cosign image which runs as user `nonroot`. Pepr sees this and mutates the user to `1000`. This causes issues when cosign then tries to write to the container. 

## Related Issue
none

## Solution
Use `uds/user` and `uds/group` as runner pod labels that can be set by CI variable per job in the `.gitlab-ci.yml` to ensure build containers run as the expected user. In case of images running as root, try to find alternative nonroot images. For cases in which the user must be root, a Pepr exemption must be made.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
