### PR TITLE
ci: add milestoned to commitlint workflow to enable ci on release

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -3,7 +3,7 @@ name: Metadata
 on:
   pull_request:
     branches: [main]
-    types: [opened, edited, synchronize]
+    types: [milestoned, opened, edited, synchronize]
 
 jobs:
   title_check:


### PR DESCRIPTION

## Description
Adds `milestoned` to the pr type on commitlint action to facilitate kicking of ci for required checks on release please PRs

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
