### PR TITLE
chore: fix unvendored kubectl and zarf, remove --no-progress flag

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -39,8 +39,8 @@ tasks:
   - name: cleanup-gitlab-runner
     description: Remove the gitlab-runner namespace
     actions:
-      - cmd: kubectl delete namespace gitlab-runner-sandbox --v=9 || true
-      - cmd: kubectl delete namespace gitlab-runner --v=9 || true
+      - cmd: uds zarf tools kubectl delete namespace gitlab-runner-sandbox --v=9 || true
+      - cmd: uds zarf tools kubectl delete namespace gitlab-runner --v=9 || true
 
   - name: cleanup-cluster
     description: Delete the k3d cluster

--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -2,5 +2,5 @@ tasks:
   - name: gitlab-bundle
     description: Create Gitlab Bundle with Dependencies
     actions:
-      - cmd: zarf package create pkg-deps/gitlab/dev-secrets/ --confirm --no-progress --architecture=${UDS_ARCH} --skip-sbom
+      - cmd: uds zarf package create pkg-deps/gitlab/dev-secrets/ --confirm --no-progress --architecture=${UDS_ARCH} --skip-sbom
       - cmd: uds create pkg-deps/gitlab/bundle --confirm --no-progress --architecture=${UDS_ARCH}

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -7,7 +7,7 @@ tasks:
   - name: gitlab-runner-package
     actions:
       - description: Deploy the UDS Gitlab Runner Package
-        cmd: zarf package deploy zarf-package-gitlab-runner-${UDS_ARCH}*.tar.zst --confirm --set job_runner_namespace=${JOB_RUNNER_NAMESPACE}
+        cmd: uds zarf package deploy zarf-package-gitlab-runner-${UDS_ARCH}*.tar.zst --confirm --set job_runner_namespace=${JOB_RUNNER_NAMESPACE}
 
   - name: gitlab-bundle
     description: Deploy UDS Package Gitlab from Bundle with Dependencies

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -26,7 +26,7 @@ tasks:
       - description: Publish the packages
         cmd: |
           set -e
-          zarf package publish zarf-package-gitlab-runner-amd64-${VERSION}.tar.zst ${TARGET_REPO}
+          uds zarf package publish zarf-package-gitlab-runner-amd64-${VERSION}.tar.zst ${TARGET_REPO}
           if [ ${FLAVOR} != "registry1" ]; then
-           zarf package publish zarf-package-gitlab-runner-arm64-${VERSION}.tar.zst ${TARGET_REPO}
+           uds zarf package publish zarf-package-gitlab-runner-arm64-${VERSION}.tar.zst ${TARGET_REPO}
           fi

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -18,9 +18,9 @@ tasks:
       - description: Create the packages
         cmd: |
           set -e
-          ZARF_ARCHITECTURE=amd64 uds run create-package --no-progress --set FLAVOR=${FLAVOR}
+          ZARF_ARCHITECTURE=amd64 uds run create-package --set FLAVOR=${FLAVOR}
           if [ ${FLAVOR} != "registry1" ]; then
-            ZARF_ARCHITECTURE=arm64 uds run create-package --no-progress --set FLAVOR=${FLAVOR}
+            ZARF_ARCHITECTURE=arm64 uds run create-package --set FLAVOR=${FLAVOR}
           fi
       
       - description: Publish the packages

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -61,7 +61,7 @@ tasks:
           # Attempt 3 times to retreive successful log statement with 30 second pause between retries
           while [ $retry_count -lt $max_retries ]; do
             # Check if the GitLab Runner pod is registered
-            if kubectl get pod -n "$namespace" -l "$pod_label_selector" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null | xargs -I {} kubectl logs -n "$namespace" {} -c gitlab-runner | grep -q "Registering runner... succeeded"; then
+            if uds zarf tools kubectl get pod -n "$namespace" -l "$pod_label_selector" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null | xargs -I {} kubectl logs -n "$namespace" {} -c gitlab-runner | grep -q "Registering runner... succeeded"; then
               # successful test
               exit 0
             fi


### PR DESCRIPTION


## Description
fix unvendored kubectl and zarf commands
remove no longer valid--no-progress flag
## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
