### PR TITLE
fix: architecture issues in nested `uds-cli` publish

### DIFF
--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -18,9 +18,9 @@ tasks:
       - description: Create the packages
         cmd: |
           set -e
-          ZARF_ARCHITECTURE=amd64 uds run create-package --set FLAVOR=${FLAVOR}
+          uds run create-package -a amd64 --set FLAVOR=${FLAVOR}
           if [ ${FLAVOR} != "registry1" ]; then
-            ZARF_ARCHITECTURE=arm64 uds run create-package --set FLAVOR=${FLAVOR}
+            uds run create-package -a arm64 --set FLAVOR=${FLAVOR}
           fi
       
       - description: Publish the packages


### PR DESCRIPTION
## Description

This fixes the publish task to properly use `-a` to pass architecture into `uds-cli`.  Relevant run with uds-cli v0.9.3 on an amd system:
![image](https://github.com/defenseunicorns/uds-package-gitlab-runner/assets/3977569/f1135562-123a-4218-b33e-9fa0bc8daf96)

## Related Issue

Fixes #51 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
