### PR TITLE
ci: reduce size of runner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   test:
     name: Create and Deploy Flavor ${{ matrix.flavor }}
-    runs-on: "uds-ubuntu-big-boy-16-core"
+    runs-on: "uds-ubuntu-big-boy-8-core"
     strategy:
       matrix:
         flavor: [upstream, registry1]    


### PR DESCRIPTION
## Description

reduce runner to 8 core since gitlab deployment has been scaled down for ci