### PR TITLE
fix: uds zarf -> ./zarf

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -18,11 +18,11 @@ components:
     actions:
       onDeploy:
         before:
-          - cmd: uds zarf tools kubectl get secret gitlab-gitlab-runner-secret -n gitlab -o=jsonpath={.data.runner-registration-token} | base64 -d
+          - cmd: ./zarf tools kubectl get secret gitlab-gitlab-runner-secret -n gitlab -o=jsonpath={.data.runner-registration-token} | base64 -d
             setVariables:
               - name: RUNNER_REGISTRATION_TOKEN
-          - cmd: uds zarf tools kubectl create namespace gitlab-runner || true
-          - cmd: uds zarf tools kubectl create secret generic gitlab-gitlab-runner-secret --namespace=gitlab-runner --from-literal=runner-registration-token="${ZARF_VAR_RUNNER_REGISTRATION_TOKEN}" --from-literal=runner-token="" --v=9 || true
+          - cmd: ./zarf tools kubectl create namespace gitlab-runner || true
+          - cmd: ./zarf tools kubectl create secret generic gitlab-gitlab-runner-secret --namespace=gitlab-runner --from-literal=runner-registration-token="${ZARF_VAR_RUNNER_REGISTRATION_TOKEN}" --from-literal=runner-token="" --v=9 || true
 
   - name: gitlab-runner
     required: true


### PR DESCRIPTION
## Description
Based on internal discussions, zarf actions should call `./zarf` rather than `uds zarf`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)