### PR TITLE
chore: add a renovate schedule to reduce paid runner churn

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     "replacements:all",
     "workarounds:all"
   ],
+  "schedule": ["after 7am and before 9am every weekday"],
   "packageRules": [
     {
       "groupName": "Gitlab Runner Support Dependencies",


### PR DESCRIPTION
## Description

Adds a renovate schedule to the repo to avoid paid runner churn

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
