### PR TITLE
chore: hotfix the update to spoof the release

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -33,13 +33,8 @@ tasks:
     description: Create UDS Gitlab Runner bundle based on the latest release
     actions:
       - task: pull:latest-package-release
-      # TODO (@WSTARR): This is currently needed to get around the chicken+egg condition when release please updates the version in GH
-      - description: Get the current Zarf package name
-        cmd: cat zarf.yaml | yq .metadata.version
-        setVariables:
-          - name: CURRENT_VERSION
-      - description: Move the latest to the current (needed to make this work on release-please PRs)
-        cmd: test -f zarf-package-gitlab-runner-${UDS_ARCH}-${CURRENT_VERSION}.tar.zst || mv zarf-package-gitlab-runner-${UDS_ARCH}-*.tar.zst zarf-package-gitlab-runner-${UDS_ARCH}-${CURRENT_VERSION}.tar.zst
+        with:
+          spoof_release: "true"
       - task: create:test-bundle
 
 # CI will execute the following (via uds-common/.github/actions/test) so they need to be here with these names


### PR DESCRIPTION
## Description

This fixes the latest release bundle to use the uds-common spoof.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
