### PR TITLE
chore: improve jest test patterns

### DIFF
--- a/test/common.ts
+++ b/test/common.ts
@@ -1,0 +1,24 @@
+import { spawnSync } from "child_process";
+
+export function zarfExec(args: string[], captureOutput = false) {
+    const argString = args.join(" ")
+    return spawnSync(
+        `uds zarf ${argString}`, {
+        // Run command in a shell
+        shell: true,
+        // Print the command output directly to the shell if we don'e want to capture it (useful for debugging)
+        stdio: captureOutput ? undefined : 'inherit'
+    });
+}
+
+export async function retry(funcCb: Function, retries = 3, timeout = 3000) {
+    let result = false
+    for (let i = 0; i < retries; i++) {
+        await new Promise(r => setTimeout(r, timeout))
+        result = await funcCb()
+        if (result) {
+            break
+        }
+    }
+    return result
+}

--- a/test/journey/registration.test.ts
+++ b/test/journey/registration.test.ts
@@ -1,22 +1,18 @@
 import { expect, test} from '@jest/globals';
 import { K8s, kind } from "kubernetes-fluent-client";
-import { spawnSync } from "child_process";
+import { zarfExec, retry } from "../common";
 
 test('test registration of the runner succeeded', async () => {
-    let foundRegistrationSuccess = false
-    for (let i = 0; i < 3; i++) {
-        await new Promise(r => setTimeout(r, 3000))
+    let foundRegistrationSuccess = await retry(async () => {
         const runnerPods = await K8s(kind.Pod).InNamespace("gitlab-runner").WithLabel("app", "gitlab-runner").Get()
         if (runnerPods.items.at(0)?.status?.phase === "Running") {
-            const podName = runnerPods.items.at(0)?.metadata?.name
-            const runnerLogs = spawnSync(
-                `uds zarf tools kubectl logs -n gitlab-runner ${podName} -c gitlab-runner`, {
-                shell: true, // Run command in a shell
-            });
+            const podName = runnerPods.items.at(0)?.metadata?.name!
+            const runnerLogs = zarfExec(["tools", "kubectl", "logs", "-n", "gitlab-runner", podName, "-c", "gitlab-runner"], true);
             if (runnerLogs.stdout.indexOf("Registering runner... succeeded") > -1) {
-                foundRegistrationSuccess = true
+                return true
             }
         }
-    }
+        return false
+    })
     expect(foundRegistrationSuccess).toBe(true)
 });


### PR DESCRIPTION
## Description

This improves the patterns for running jest tests for GLR - we decided against cypress and playwright because both run the tests in browser and cannot make use of spawnSync or KFC.

## Related Issue

Fixes #72 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
