### PR TITLE
feat: add wait for GLR package CR readiness

### DIFF
--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -26,3 +26,20 @@ components:
           - cmd: ./zarf tools kubectl label secret -n gitlab-runner gitlab-gitlab-runner-secret app.kubernetes.io/managed-by=Helm || true
           - cmd: ./zarf tools kubectl annotate secret -n gitlab-runner gitlab-gitlab-runner-secret meta.helm.sh/release-name=uds-gitlab-runner-config || true
           - cmd: ./zarf tools kubectl annotate secret -n gitlab-runner gitlab-gitlab-runner-secret meta.helm.sh/release-namespace=gitlab-runner || true
+        after:
+          - description: Validate GitLab Runner Package
+            maxTotalSeconds: 300
+            wait:
+              cluster:
+                kind: Packages
+                name: gitlab-runner
+                namespace: gitlab-runner
+                condition: "'{.status.phase}'=Ready"
+          - description: Validate GitLab Runner Sandbox Package
+            maxTotalSeconds: 300
+            wait:
+              cluster:
+                kind: Packages
+                name: gitlab-runner-sandbox
+                namespace: gitlab-runner-sandbox
+                condition: "'{.status.phase}'=Ready"


### PR DESCRIPTION
## Description

Adds a wait action for the GLR package CR. This is consistent with the pattern in uds-core however it runs after the GitLab Runner chart installs (meaning the GitLab Runner chart may still fail waiting on resources like secrets to exist) however this will catch other issues such as failed updates to resources or missing resources the chart doesn't directly depend on like netpols.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
