### PR TITLE
chore: fix renovate config for gitlab runner sandbox images

### DIFF
--- a/values/registry1-values.yaml
+++ b/values/registry1-values.yaml
@@ -10,8 +10,10 @@ runners:
   job:
     registry: "###ZARF_REGISTRY###"
     repository: ironbank/redhat/ubi/ubi9
+    # renovate: datasource=docker depName=registry1.dso.mil/ironbank/redhat/ubi/ubi9 versioning=semver
     tag: "9.4"
   helper:
     registry: "###ZARF_REGISTRY###"
     repository: ironbank/gitlab/gitlab-runner/gitlab-runner-helper
+    # renovate: datasource=docker depName=registry1.dso.mil/ironbank/gitlab/gitlab-runner/gitlab-runner-helper versioning=semver
     tag: v17.0.0

--- a/values/upstream-values.yaml
+++ b/values/upstream-values.yaml
@@ -7,8 +7,10 @@ runners:
   job:
     registry: "###ZARF_REGISTRY###"
     repository: library/alpine
+    # renovate: datasource=docker depName=library/alpine versioning=semver
     tag: "3.19.1"
   helper:
     registry: "###ZARF_REGISTRY###"
     repository: gitlab-org/ci-cd/gitlab-runner-ubi-images/gitlab-runner-helper-ocp
+    # renovate: datasource=docker depName=registry.gitlab.com/gitlab-org/ci-cd/gitlab-runner-ubi-images/gitlab-runner-helper-ocp versioning=semver
     tag: v17.0.0


### PR DESCRIPTION
## Description

Fixes renovate being able to detect the Helm values now that they use `###ZARF_REGISTRY###`

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
