### PR TITLE
fix: downgrade destination rule to support older clusters

### DIFF
--- a/chart/templates/plugin-registry.yaml
+++ b/chart/templates/plugin-registry.yaml
@@ -62,7 +62,7 @@ spec:
     port: 80
     targetPort: 5000
 ---
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   name: gitlab-runner-registry-destination


### PR DESCRIPTION
## Description

This downgrades the DestinationRule in GLR's fleeting config since it will not run on older clusters.

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
