### PR TITLE
chore: improve helm value flexibility

### DIFF
--- a/chart/templates/plugin-registry.yaml
+++ b/chart/templates/plugin-registry.yaml
@@ -25,7 +25,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: ghcr.io/defenseunicorns/uds-package-gitlab-runner/gitlab-runner-plugins:latest
+          image: {{ .Values.pluginRegistryImage }}
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,6 +15,8 @@ runnerAuthToken: "###ZARF_VAR_RUNNER_AUTH_TOKEN###"
 
 enableSecurityCapabilities: false
 
+pluginRegistryImage: ghcr.io/defenseunicorns/uds-package-gitlab-runner/gitlab-runner-plugins:latest
+
 custom: []
   # - direction: Egress
   #   remoteGenerated: Anywhere

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -18,8 +18,6 @@ enableSecurityCapabilities: ###ZARF_VAR_ENABLE_SECURITY_CAPABILITIES###
 
 runners:
   secret: gitlab-gitlab-runner-secret
-  runUntagged: true
-  protected: true
   job:
     namespace: "###ZARF_VAR_RUNNER_SANDBOX_NAMESPACE###"
   helper:


### PR DESCRIPTION
## Description

This improves Helm value flexibility by:

1. Allowing the plugin registry image to be overridden
2. Removing deprecated values from the main chart

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
