### PR TITLE
chore!: update custom network properties key

### DIFF
--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -5,7 +5,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.sandboxNamespace }}
+  name: {{ .Values.kubernetesSandbox.namespace }}
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "pods", "pods/attach", "secrets", "services"]

--- a/chart/templates/namespace.yaml
+++ b/chart/templates/namespace.yaml
@@ -5,8 +5,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.sandboxNamespace }}
-  {{- if .Values.sandboxZarfIgnore }}
+  name: {{ .Values.kubernetesSandbox.namespace }}
+  {{- if .Values.kubernetesSandbox.zarfIgnore }}
   labels:
     zarf.dev/agent: ignore
   {{- end }}

--- a/chart/templates/rolebinding.yaml
+++ b/chart/templates/rolebinding.yaml
@@ -5,8 +5,8 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.sandboxNamespace }}
-  namespace: {{ .Values.sandboxNamespace }}
+  name: {{ .Values.kubernetesSandbox.namespace }}
+  namespace: {{ .Values.kubernetesSandbox.namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccountName }}
@@ -14,5 +14,5 @@ subjects:
 roleRef:
   apiGroup: ""
   kind: ClusterRole
-  name: {{ .Values.sandboxNamespace }}
+  name: {{ .Values.kubernetesSandbox.namespace }}
 {{- end }}

--- a/chart/templates/uds-package-sandbox.yaml
+++ b/chart/templates/uds-package-sandbox.yaml
@@ -27,7 +27,7 @@ spec:
         port: 443
         description: "UDS Tenant Gateway Services"
 
-    {{- range .Values.customSandbox }}
+    {{- range .Values.kubernetesSandbox.additionalNetworkAllow }}
       - direction: {{ .direction }}
         selector:
           {{ .selector | toYaml | nindent 10 }}

--- a/chart/templates/uds-package-sandbox.yaml
+++ b/chart/templates/uds-package-sandbox.yaml
@@ -6,7 +6,7 @@ apiVersion: uds.dev/v1alpha1
 kind: Package
 metadata:
   name: gitlab-runner-sandbox
-  namespace: {{ .Values.sandboxNamespace }}
+  namespace: {{ .Values.kubernetesSandbox.namespace }}
 spec:
   network:
     allow:

--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -35,7 +35,7 @@ spec:
       - direction: Egress
         selector:
           app: gitlab-runner
-        remoteNamespace: {{ .Values.sandboxNamespace }}
+        remoteNamespace: {{ .Values.kubernetesSandbox.namespace }}
         remoteSelector:
           uds/network-access-gitlab: "true"
     {{- end }}

--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -50,7 +50,7 @@ spec:
     {{- end }}
 
       # Custom rules for unanticipated scenarios
-    {{- range .Values.custom }}
+    {{- range .Values.additionalNetworkAllow }}
       - direction: {{ .direction }}
         selector:
           {{ .selector | toYaml | nindent 10 }}

--- a/chart/templates/uds-policy-exemptions.yaml
+++ b/chart/templates/uds-policy-exemptions.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-{{- if .Values.enableSecurityCapabilities }}
+{{- if .Values.kubernetesSandbox.enableSecurityExceptions }}
 apiVersion: uds.dev/v1alpha1
 kind: Exemption
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -21,7 +21,17 @@ additionalNetworkAllow: []
   # - direction: Egress
   #   remoteGenerated: Anywhere
   #   description: "Egress from to external GitLab"
-additionalNetworkAllowSandbox: []
-  # - direction: Egress
-  #   remoteGenerated: Anywhere
-  #   description: "Egress from to external GitLab"
+
+kubernetesSandbox:
+  namespace: "###ZARF_VAR_RUNNER_SANDBOX_NAMESPACE###"
+
+  # whether to have the Zarf Agent ignore the sandbox namespace
+  zarfIgnore: true
+
+  # whether to allow securityContext capabilities like SET_UID/SET_GID in the sandbox: https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/docs/configuration.md#allow-setuid-and-setgid-security-capabilities
+  enableSecurityExceptions: false
+
+  additionalNetworkAllow: []
+    # - direction: Egress
+    #   remoteGenerated: Anywhere
+    #   description: "Egress from to external GitLab"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,16 +4,9 @@
 # which executor to use, either 'kubernetes' or 'instance'
 executor: "kubernetes"
 
-sandboxNamespace: "###ZARF_VAR_RUNNER_SANDBOX_NAMESPACE###"
-
-# whether to have the Zarf Agent ignore the sandbox namespace
-sandboxZarfIgnore: true
-
 serviceAccountName: "gitlab-runner"
 
 runnerAuthToken: "###ZARF_VAR_RUNNER_AUTH_TOKEN###"
-
-enableSecurityCapabilities: false
 
 pluginRegistryImage: ghcr.io/defenseunicorns/uds-package-gitlab-runner/gitlab-runner-plugins:latest
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,11 +17,11 @@ enableSecurityCapabilities: false
 
 pluginRegistryImage: ghcr.io/defenseunicorns/uds-package-gitlab-runner/gitlab-runner-plugins:latest
 
-custom: []
+additionalNetworkAllow: []
   # - direction: Egress
   #   remoteGenerated: Anywhere
   #   description: "Egress from to external GitLab"
-customSandbox: []
+additionalNetworkAllowSandbox: []
   # - direction: Egress
   #   remoteGenerated: Anywhere
   #   description: "Egress from to external GitLab"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,7 +41,7 @@ If you would like to setup a different kind of runner or add your own informatio
 
 ### Allow Zarf Mutation in Sandbox
 
-By default the sandbox is excluded from being mutated by Zarf to allow external images to be used in Zarf.  If you would like to change this behavior you can do so by overriding the `sandboxZarfIgnore` value in the `uds-gitlab-runner-config` chart to `false` along with overriding the `runners.job.registry` and `runners.helper.registry` to the registry corresponding to your package flavor (`docker.io` and `registry1.dso.mil` respectively for `upstream` and `registry1.dso.mil` and `registry1.dso.mil` respectively for `registry1`)
+By default the sandbox is excluded from being mutated by Zarf to allow external images to be used in Zarf.  If you would like to change this behavior you can do so by overriding the `kubernetesSandbox.zarfIgnore` value in the `uds-gitlab-runner-config` chart to `false` along with overriding the `runners.job.registry` and `runners.helper.registry` to the registry corresponding to your package flavor (`docker.io` and `registry1.dso.mil` respectively for `upstream` and `registry1.dso.mil` and `registry1.dso.mil` respectively for `registry1`)
 
 > [!NOTE]
 > By default images pulled from private registries will need to follow the [GitLab documentation](https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#access-an-image-from-a-private-container-registry) in order to setup login information to pull from private registries.  The `kubelet` will also need network access to these registries.  If you change the configuration for Zarf to mutate images, instead, it will add this information on its own, _but_ you will _only_ be able to pull images that are available in the Zarf registry.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ sysctl -w user.max_user_namespaces=30110
 Network policies are controlled via the `uds-gitlab-runner-config` chart in accordance with the [common patterns for networking within UDS Software Factory](https://github.com/defenseunicorns/uds-software-factory/blob/main/docs/networking.md).  Because GitLab runners do not interact with external resources like databases or object storage they only implement `custom` networking for both the runner namespace and the runner sandbox namespace:
 
 - `additionalNetworkAllow`: sets custom network policies for the GitLab runner namespace - note this is _not_ where jobs run and is the orchestration side of the GitLab runner deployment.
-- `additionalNetworkAllowSandbox`: sets custom network policies for the GitLab runner sandbox namespace - this is where jobs will execute and can be used to allow them to access external services.
+- `kubernetesSandbox.additionalNetworkAllow`: sets custom network policies for the GitLab runner sandbox namespace - this is where jobs will execute and can be used to allow them to access external services.
 
 ## Runner
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,8 +18,8 @@ sysctl -w user.max_user_namespaces=30110
 
 Network policies are controlled via the `uds-gitlab-runner-config` chart in accordance with the [common patterns for networking within UDS Software Factory](https://github.com/defenseunicorns/uds-software-factory/blob/main/docs/networking.md).  Because GitLab runners do not interact with external resources like databases or object storage they only implement `custom` networking for both the runner namespace and the runner sandbox namespace:
 
-- `custom`: sets custom network policies for the GitLab runner namespace - note this is _not_ where jobs run and is the orchestration side of the GitLab runner deployment.
-- `customSandbox`: sets custom network policies for the GitLab runner sandbox namespace - this is where jobs will execute and can be used to allow them to access external services.
+- `additionalNetworkAllow`: sets custom network policies for the GitLab runner namespace - note this is _not_ where jobs run and is the orchestration side of the GitLab runner deployment.
+- `additionalNetworkAllowSandbox`: sets custom network policies for the GitLab runner sandbox namespace - this is where jobs will execute and can be used to allow them to access external services.
 
 ## Runner
 

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -14,7 +14,8 @@ rbac:
 serviceAccount:
   name: gitlab-runner
 
-kubernetesSandbox.enableSecurityExceptions: ###ZARF_VAR_ENABLE_SECURITY_CAPABILITIES###
+kubernetesSandbox:
+  enableSecurityExceptions: ###ZARF_VAR_ENABLE_SECURITY_CAPABILITIES###
 
 runners:
   secret: gitlab-gitlab-runner-secret

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -14,7 +14,7 @@ rbac:
 serviceAccount:
   name: gitlab-runner
 
-enableSecurityCapabilities: ###ZARF_VAR_ENABLE_SECURITY_CAPABILITIES###
+kubernetesSandbox.enableSecurityExceptions: ###ZARF_VAR_ENABLE_SECURITY_CAPABILITIES###
 
 runners:
   secret: gitlab-gitlab-runner-secret

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -74,7 +74,7 @@ runners:
         "uds/user" = "${UDS_RUN_AS_USER}"
         "uds/group" = "${UDS_RUN_AS_GROUP}"
         "uds/network-access-gitlab" = "true"
-      {{- if .Values.enableSecurityCapabilities }}
+      {{- if .Values.kubernetesSandbox.enableSecurityExceptions }}
       [runners.kubernetes.build_container_security_context]
         [runners.kubernetes.build_container_security_context.capabilities]
           add = ["SETUID", "SETGID"]

--- a/values/config-values.yaml
+++ b/values/config-values.yaml
@@ -1,4 +1,5 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-kubernetesSandbox.enableSecurityExceptions: ###ZARF_VAR_ENABLE_SECURITY_CAPABILITIES###
+kubernetesSandbox:
+  enableSecurityExceptions: ###ZARF_VAR_ENABLE_SECURITY_CAPABILITIES###

--- a/values/config-values.yaml
+++ b/values/config-values.yaml
@@ -1,4 +1,4 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-enableSecurityCapabilities: ###ZARF_VAR_ENABLE_SECURITY_CAPABILITIES###
+kubernetesSandbox.enableSecurityExceptions: ###ZARF_VAR_ENABLE_SECURITY_CAPABILITIES###


### PR DESCRIPTION
## Description

- Updating all instances of custom: [] to additionalNetworkAllow: []

> [!CAUTION]
> **BREAKING CHANGE** `custom` has changed to `additionalNetworkAllow` and sandbox namespace values have been moved under `kubernetesSandbox`

## Related Issue

Fixes #
<!-- or -->
Relates to #
https://github.com/orgs/defenseunicorns/projects/118/views/12?pane=issue&itemId=87152090&issue=defenseunicorns%7Cuds-package-maintenance%7C5
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
