### PR TITLE
fix: default the registry URL to use the correct namespace by default

### DIFF
--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -37,7 +37,7 @@ runners:
     policy:
       idle_count: 5
       idle_time: "20m0s"
-    registry: "gitlab-runner-registry.gitlab-runner.svc.cluster.local"
+    registry: "gitlab-runner-registry.{{ .Release.Namespace }}.svc.cluster.local"
     repository: gitlab-org/fleeting/plugins/aws
     tag: "1.0.0"
 
@@ -48,7 +48,7 @@ runners:
       cache_dir = "/tmp/gitlab-runner/cache"
     {{- if eq .Values.runners.executor "instance" }}
       [runners.autoscaler]
-        plugin = "{{ printf "%s/%s:%s" .Values.runners.fleeting.registry .Values.runners.fleeting.repository .Values.runners.fleeting.tag }}"
+        plugin = "{{ printf "%s/%s:%s" (tpl .Values.runners.fleeting.registry .) .Values.runners.fleeting.repository .Values.runners.fleeting.tag }}"
 
         capacity_per_instance = 1
         max_use_count = 1


### PR DESCRIPTION
## Description

This defaults the registry URL to use the correct namespace by default and allow templating it

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
