### PR TITLE
fix: fix plugin registry

### DIFF
--- a/chart/templates/plugin-registry.yaml
+++ b/chart/templates/plugin-registry.yaml
@@ -30,7 +30,7 @@ spec:
           command:
           - /bin/registry
           - serve
-          - /etc/docker/registry/config.yml
+          - /etc/distribution/config.yaml
           ports:
             - containerPort: 5000
           livenessProbe:

--- a/chart/templates/plugin-registry.yaml
+++ b/chart/templates/plugin-registry.yaml
@@ -30,7 +30,7 @@ spec:
           command:
           - /bin/registry
           - serve
-          - /etc/distribution/config.yaml
+          - /etc/distribution/config.yml
           ports:
             - containerPort: 5000
           livenessProbe:

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=registry.gitlab.com/gitlab-org/gitlab-runner extractVersion=^alpine-v(?<version>\d+\.\d+\.\d+)$
-    version: 17.10.1-uds.0
+    version: 17.10.1-uds.1
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/gitlab/gitlab-runner/gitlab-runner extractVersion=^v(?<version>\d+\.\d+\.\d+)$
-    version: 17.10.0-uds.0
+    version: 17.10.0-uds.1
   - name: unicorn
     # renovate-uds: datasource=docker depName=cgr.dev/du-uds-defenseunicorns/gitlab-runner-fips
-    version: 17.10.1-uds.0
+    version: 17.10.1-uds.1


### PR DESCRIPTION
## Description

An update in the underlying registry image used in the plugin registry changed the config file path and that broke the registry serve command. This PR updates the config file passed to the serve command to the correct location

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
