### PR TITLE
chore: adding support for docker autoscaler

### DIFF
--- a/chart/templates/plugin-registry.yaml
+++ b/chart/templates/plugin-registry.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-{{- if eq .Values.executor "instance" }}
+{{- if has .Values.executor (list "instance" "docker-autoscaler") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -40,7 +40,7 @@ spec:
           uds/network-access-gitlab: "true"
     {{- end }}
 
-    {{- if eq .Values.executor "instance" }}
+    {{- if has .Values.executor (list "instance" "docker-autoscaler") }}
       - direction: Ingress
         remoteGenerated: IntraNamespace
       - direction: Egress

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,11 +67,12 @@ By default the chart will create a service account named `gitlab-runner`.  You c
 
 ### Change the Runner Executor
 
-This package supports both the Kubernetes executor and the instance fleeting executor for running CI jobs.  The Kubernetes executor is default, but to swap to the fleeting executor change the following:
+This package supports Kubernetes executor, docker-autoscaler, and instance fleeting executor for running CI jobs.  The Kubernetes executor is default, but to swap to the fleeting executor change the following:
 
 #### `uds-gitlab-runner-config` chart:
 
 - `executor` - set this to `instance` to flip the executor to use fleeting instances
+- `executor` - set this to `docker-autoscaler` to enable docker based CI options. It still relies on instance runner configuration.
 
 #### `gitlab-runner` chart:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ By default the chart will create a service account named `gitlab-runner`.  You c
 
 ### Change the Runner Executor
 
-This package supports Kubernetes executor, docker-autoscaler, and instance fleeting executor for running CI jobs.  The Kubernetes executor is default, but to swap to the fleeting executor change the following:
+This package supports Kubernetes executor, docker-autoscaler, and instance fleeting executor for running CI jobs.  The Kubernetes executor is default, but to swap to either of the fleeting-based executors change the following:
 
 #### `uds-gitlab-runner-config` chart:
 

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -51,6 +51,7 @@ runners:
     {{- if eq .Values.runners.executor "docker-autoscaler" }}
       [runners.docker]
           image = "{{ printf "%s/%s:%s" .Values.runners.job.registry .Values.runners.job.repository .Values.runners.job.tag }}"
+          volumes = ["/var/run/docker.sock:/var/run/docker.sock"]
     {{- end }}
     {{- if has .Values.runners.executor (list "instance" "docker-autoscaler") }}
       [runners.autoscaler]

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -48,7 +48,7 @@ runners:
       url = "https://gitlab.###ZARF_VAR_DOMAIN###"
       clone_url = "https://gitlab.###ZARF_VAR_DOMAIN###"
       cache_dir = "/tmp/gitlab-runner/cache"
-      
+   
     {{- if eq .Values.runners.executor "docker-autoscaler" }}
       [runners.docker]
           image = "{{ printf "%s/%s:%s" .Values.runners.job.registry .Values.runners.job.repository .Values.runners.job.tag }}"

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -50,9 +50,9 @@ runners:
       cache_dir = "/tmp/gitlab-runner/cache"
       
     {{- if eq .Values.runners.executor "docker-autoscaler" }}
-    [runners.docker]
-        image = "{{ .Values.runners.docker.image }}"
-    {{- else }}
+      [runners.docker]
+          image = "busybox:latest"
+    {{- end }}
 
     {{- if has .Values.runners.executor (list "instance" "docker-autoscaler") }}
       [runners.autoscaler]

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -51,7 +51,7 @@ runners:
       
     {{- if eq .Values.runners.executor "docker-autoscaler" }}
       [runners.docker]
-          image = "busybox:latest"
+          image = "{{ printf "%s/%s:%s" .Values.runners.job.registry .Values.runners.job.repository .Values.runners.job.tag }}"
     {{- end }}
 
     {{- if has .Values.runners.executor (list "instance" "docker-autoscaler") }}

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -48,7 +48,13 @@ runners:
       url = "https://gitlab.###ZARF_VAR_DOMAIN###"
       clone_url = "https://gitlab.###ZARF_VAR_DOMAIN###"
       cache_dir = "/tmp/gitlab-runner/cache"
-    {{- if eq .Values.runners.executor "instance" }}
+      
+    {{- if eq .Values.runners.executor "docker-autoscaler" }}
+    [runners.docker]
+        image = "{{ .Values.runners.docker.image }}"
+    {{- else }}
+
+    {{- if has .Values.runners.executor (list "instance" "docker-autoscaler") }}
       [runners.autoscaler]
         plugin = "{{ printf "%s/%s:%s" (tpl .Values.runners.fleeting.registry .) .Values.runners.fleeting.repository .Values.runners.fleeting.tag }}"
 

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -48,12 +48,10 @@ runners:
       url = "https://gitlab.###ZARF_VAR_DOMAIN###"
       clone_url = "https://gitlab.###ZARF_VAR_DOMAIN###"
       cache_dir = "/tmp/gitlab-runner/cache"
-   
     {{- if eq .Values.runners.executor "docker-autoscaler" }}
       [runners.docker]
           image = "{{ printf "%s/%s:%s" .Values.runners.job.registry .Values.runners.job.repository .Values.runners.job.tag }}"
     {{- end }}
-
     {{- if has .Values.runners.executor (list "instance" "docker-autoscaler") }}
       [runners.autoscaler]
         plugin = "{{ printf "%s/%s:%s" (tpl .Values.runners.fleeting.registry .) .Values.runners.fleeting.repository .Values.runners.fleeting.tag }}"


### PR DESCRIPTION
## Description

Docker Autoscaler: https://docs.gitlab.com/runner/executors/docker_autoscaler/ 

It wraps the [Docker executor](https://docs.gitlab.com/runner/executors/docker/) so that all Docker executor options and features are supported.

This builds on top of the existing 'instance' executor configurations. 

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
