### PR TITLE
fix: default imagePullPolicy for Plugin Deployment to Always

### DIFF
--- a/chart/templates/plugin-registry.yaml
+++ b/chart/templates/plugin-registry.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-{{- if has .Values.executor (list "instance" "docker-autoscaler") }}
+{{- if and (has .Values.executor (list "instance" "docker-autoscaler")) .Values.pluginRegistry.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,8 +25,8 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: {{ .Values.pluginRegistryImage }}
-          imagePullPolicy: IfNotPresent
+          image: {{ .Values.pluginRegistry.image }}
+          imagePullPolicy: {{ .Values.pluginRegistry.imagePullPolicy }}
           command:
           - /bin/registry
           - serve

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,8 +13,7 @@ pluginRegistry:
   image: ghcr.io/defenseunicorns/uds-package-gitlab-runner/gitlab-runner-plugins:latest
   imagePullPolicy: Always
 
-additionalNetworkAllow:
-  []
+additionalNetworkAllow: []
   # - direction: Egress
   #   remoteGenerated: Anywhere
   #   description: "Egress from to external GitLab"
@@ -28,8 +27,7 @@ kubernetesSandbox:
   # whether to allow securityContext capabilities like SET_UID/SET_GID in the sandbox: https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/docs/configuration.md#allow-setuid-and-setgid-security-capabilities
   enableSecurityExceptions: false
 
-  additionalNetworkAllow:
-    []
+  additionalNetworkAllow: []
     # - direction: Egress
     #   remoteGenerated: Anywhere
     #   description: "Egress from to external GitLab"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,9 +8,13 @@ serviceAccountName: "gitlab-runner"
 
 runnerAuthToken: "###ZARF_VAR_RUNNER_AUTH_TOKEN###"
 
-pluginRegistryImage: ghcr.io/defenseunicorns/uds-package-gitlab-runner/gitlab-runner-plugins:latest
+pluginRegistry:
+  enabled: true
+  image: ghcr.io/defenseunicorns/uds-package-gitlab-runner/gitlab-runner-plugins:latest
+  imagePullPolicy: Always
 
-additionalNetworkAllow: []
+additionalNetworkAllow:
+  []
   # - direction: Egress
   #   remoteGenerated: Anywhere
   #   description: "Egress from to external GitLab"
@@ -24,7 +28,8 @@ kubernetesSandbox:
   # whether to allow securityContext capabilities like SET_UID/SET_GID in the sandbox: https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/docs/configuration.md#allow-setuid-and-setgid-security-capabilities
   enableSecurityExceptions: false
 
-  additionalNetworkAllow: []
+  additionalNetworkAllow:
+    []
     # - direction: Egress
     #   remoteGenerated: Anywhere
     #   description: "Egress from to external GitLab"

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=registry.gitlab.com/gitlab-org/gitlab-runner extractVersion=^alpine-v(?<version>\d+\.\d+\.\d+)$
-    version: 17.10.1-uds.2
+    version: 17.10.1-uds.3
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/gitlab/gitlab-runner/gitlab-runner extractVersion=^v(?<version>\d+\.\d+\.\d+)$
-    version: 17.10.0-uds.2
+    version: 17.10.0-uds.3
   - name: unicorn
     # renovate-uds: datasource=docker depName=cgr.dev/du-uds-defenseunicorns/gitlab-runner-fips
-    version: 17.10.1-uds.2
+    version: 17.10.1-uds.3


### PR DESCRIPTION
## Description
Updates the template for the Plugin Registry deployment to allow user to configure the imagePullPolicy, and sets the policy to `Always` by default.  Additionally allows users to opt out of deploying the plugin registry in the event they are using a fleeting plugin that is not included in the plugin registry image.

## Related Issue

Fixes #177 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
