### PR TITLE
fix: configurable rbac namespace

### DIFF
--- a/chart/templates/rolebinding.yaml
+++ b/chart/templates/rolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccountName }}
-    namespace: gitlab-runner
+    namespace: {{ .Values.runnerNamespace }}
 roleRef:
   apiGroup: ""
   kind: ClusterRole

--- a/chart/templates/rolebinding.yaml
+++ b/chart/templates/rolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccountName }}
-    namespace: {{ .Values.runnerNamespace }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: ""
   kind: ClusterRole

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,9 +8,6 @@ serviceAccountName: "gitlab-runner"
 
 runnerAuthToken: "###ZARF_VAR_RUNNER_AUTH_TOKEN###"
 
-# The namespace in which the runner scheduler is deployed
-runnerNamespace: gitlab-runner
-
 pluginRegistry:
   enabled: true
   image: ghcr.io/defenseunicorns/uds-package-gitlab-runner/gitlab-runner-plugins:latest
@@ -22,7 +19,6 @@ additionalNetworkAllow: []
 #   description: "Egress from to external GitLab"
 
 kubernetesSandbox:
-  # The namespace in which the job pods are deployed
   namespace: "###ZARF_VAR_RUNNER_SANDBOX_NAMESPACE###"
 
   # whether to have the Zarf Agent ignore the sandbox namespace

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,17 +8,21 @@ serviceAccountName: "gitlab-runner"
 
 runnerAuthToken: "###ZARF_VAR_RUNNER_AUTH_TOKEN###"
 
+# The namespace in which the runner scheduler is deployed
+runnerNamespace: gitlab-runner
+
 pluginRegistry:
   enabled: true
   image: ghcr.io/defenseunicorns/uds-package-gitlab-runner/gitlab-runner-plugins:latest
   imagePullPolicy: Always
 
 additionalNetworkAllow: []
-  # - direction: Egress
-  #   remoteGenerated: Anywhere
-  #   description: "Egress from to external GitLab"
+# - direction: Egress
+#   remoteGenerated: Anywhere
+#   description: "Egress from to external GitLab"
 
 kubernetesSandbox:
+  # The namespace in which the job pods are deployed
   namespace: "###ZARF_VAR_RUNNER_SANDBOX_NAMESPACE###"
 
   # whether to have the Zarf Agent ignore the sandbox namespace
@@ -28,6 +32,6 @@ kubernetesSandbox:
   enableSecurityExceptions: false
 
   additionalNetworkAllow: []
-    # - direction: Egress
-    #   remoteGenerated: Anywhere
-    #   description: "Egress from to external GitLab"
+  # - direction: Egress
+  #   remoteGenerated: Anywhere
+  #   description: "Egress from to external GitLab"

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=registry.gitlab.com/gitlab-org/gitlab-runner extractVersion=^alpine-v(?<version>\d+\.\d+\.\d+)$
-    version: 17.10.1-uds.3
+    version: 17.10.1-uds.4
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/gitlab/gitlab-runner/gitlab-runner extractVersion=^v(?<version>\d+\.\d+\.\d+)$
-    version: 17.10.0-uds.3
+    version: 17.10.0-uds.4
   - name: unicorn
     # renovate-uds: datasource=docker depName=cgr.dev/du-uds-defenseunicorns/gitlab-runner-fips
-    version: 17.10.1-uds.3
+    version: 17.10.1-uds.4


### PR DESCRIPTION
## Description
Currently the [namespace](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/chart/templates/rolebinding.yaml) used by the ClusterRoleBinding resource is hardcoded to be `gitlab-runner`.  In situations where multiple runners are desired, this namespace will be unique per deployment of this package, so we must allow users to determine which namespace contains the service account that will be creating resources in the sandbox namespace.  Not doing this results in immediately job failures as the scheduler pod cannot perform any actions in the sandbox namespace.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
