### PR TITLE
chore: attempt to fix broken renovate comments

### DIFF
--- a/values/upstream-values.yaml
+++ b/values/upstream-values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: registry.gitlab.com
   image: gitlab-org/gitlab-runner
-  # renovate: datasource=docker depName=registry.gitlab.com/gitlab-org/gitlab-runner versioning=semver extractVersion=^alpine-v(?<version>\\d+\\.\\d+\\.\\d+)$
+  # renovate: datasource=docker depName=registry.gitlab.com/gitlab-org/gitlab-runner versioning=semver extractVersion=^alpine-v(?<version>\d+\.\d+\.\d+)$
   tag: alpine-v17.7.0
 
 runners:

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -57,7 +57,7 @@ components:
         valuesFiles:
           - values/upstream-values.yaml
     images:
-      - "registry.gitlab.com/gitlab-org/gitlab-runner:alpine-v17.7.0" # renovate: extractVersion=^alpine-v(?<version>\\d+\\.\\d+\\.\\d+)$
+      - "registry.gitlab.com/gitlab-org/gitlab-runner:alpine-v17.7.0" # renovate: extractVersion=^alpine-v(?<version>\d+\.\d+\.\d+)$
       - "registry.gitlab.com/gitlab-org/ci-cd/gitlab-runner-ubi-images/gitlab-runner-helper-ocp:v18.0.1"
       - "library/alpine:3.22.0"
 


### PR DESCRIPTION
Updated the renovate comment extractVersion that isnt working to match the one in releaser.yaml that is working (remove extra `\`)