### PR TITLE
fix: update autoscaler runner templating

### DIFF
--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=registry.gitlab.com/gitlab-org/gitlab-runner extractVersion=^alpine-v(?<version>\d+\.\d+\.\d+)$
-    version: 18.1.1-uds.0
+    version: 18.1.1-uds.1
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/gitlab/gitlab-runner/gitlab-runner extractVersion=^v(?<version>\d+\.\d+\.\d+)$
-    version: 18.0.2-uds.0
+    version: 18.0.2-uds.1
   - name: unicorn
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/gitlab/gitlab-runner/gitlab-runner extractVersion=^v(?<version>\d+\.\d+\.\d+)$
-    version: 18.0.2-uds.0
+    version: 18.0.2-uds.1

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -68,7 +68,9 @@ runners:
         [runners.autoscaler.plugin_config]
           {{- toToml .Values.runners.fleeting.pluginConfig | nindent 6 }}
         [runners.autoscaler.connector_config]
-          {{- toToml .Values.runners.fleeting.connectorConfig | nindent 6 }}
+          {{- $cfg := deepCopy .Values.runners.fleeting.connectorConfig }}
+          {{- $_ := set $cfg "protocol_port" (int $cfg.protocol_port) }}
+          {{- toToml $cfg | nindent 6 }}
         [[runners.autoscaler.policy]]
           idle_count = {{ .Values.runners.fleeting.policy.idle_count }}
           idle_time = {{ .Values.runners.fleeting.policy.idle_time | quote }}


### PR DESCRIPTION
## Description

Explicitly cast runners.autoscaler.connector_config.protocol_port as int as toToml makes it a float. This behavior is not new, but gitlab runner 18.x now strictly enforces type. Passing as a string results in a similar error.

```
Merging configuration from template file "/configmaps/config.template.toml" 
FATAL: Could not handle configuration merging from template file  error=couldn't load configuration template file: decoding configuration file: toml: line 31 (last key "runners.autoscaler.connector_config.protocol_port"): incompatible types: TOML value has type float64; destination has type integer
```

Built and deployed package locally with change and confirmed it resolves the issue observed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
