### PR TITLE
feat: allow passing additional runners.kubernetes options

### DIFF
--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=registry.gitlab.com/gitlab-org/gitlab-runner extractVersion=^alpine-v(?<version>\d+\.\d+\.\d+)$
-    version: 18.3.0-uds.0
+    version: 18.3.0-uds.1
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/gitlab/gitlab-runner/gitlab-runner extractVersion=^v(?<version>\d+\.\d+\.\d+)$
-    version: 18.3.0-uds.0
+    version: 18.3.0-uds.1
   - name: unicorn
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/gitlab/gitlab-runner/gitlab-runner extractVersion=^v(?<version>\d+\.\d+\.\d+)$
-    version: 18.3.0-uds.0
+    version: 18.3.0-uds.1

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -31,6 +31,8 @@ runners:
   allowedPullPolicies: []
   autoscaler:
     extra_config: {}
+  kubernetes:
+    extra_config: {}
 
   fleeting:
     maxInstances: 10
@@ -85,9 +87,12 @@ runners:
         helper_image = "{{ printf "%s/%s:%s" .Values.runners.helper.registry .Values.runners.helper.repository .Values.runners.helper.tag }}"
         image = "{{ printf "%s/%s:%s" .Values.runners.job.registry .Values.runners.job.repository .Values.runners.job.tag }}"
         image_pull_secrets = ["private-registry"]
-      {{- if .Values.runners.allowedPullPolicies }}
+        {{- if .Values.runners.allowedPullPolicies }}
         allowed_pull_policies = [{{ range $index, $val := .Values.runners.allowedPullPolicies }}{{ if $index }}, {{ end }}"{{ $val }}"{{ end }}]
-      {{- end }}
+        {{- end }}
+        {{- if gt (len .Values.runners.kubernetes.extra_config) 0 }}
+        {{- toToml .Values.runners.kubernetes.extra_config | nindent 4 }}
+        {{- end }}
       [runners.kubernetes.pod_labels]
         "job_id" = "${CI_JOB_ID}"
         "job_name" = "${CI_JOB_NAME}"


### PR DESCRIPTION
## Description

Add escape hatch to allow passing additional runners.kubernetes options:
https://docs.gitlab.com/runner/configuration/advanced-configuration/#the-runnerskubernetes-section

Built package locally and deployed onto rke2 cluster to confirm values passed through as expected.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab-runner/blob/main/CONTRIBUTING.md#developer-workflow) followed
